### PR TITLE
Fix horizon tests and DM variance, add verbose validation flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ from models import (
 )
 from sampling import sample_events_value_weighted, analyze_sample_characteristics, validate_sampling_randomness
 from evaluation import (
-    calculate_forecast_errors, calculate_rmse, calculate_mae, paired_t_test,
+    calculate_forecast_errors, calculate_rmse, calculate_mae,
     diebold_mariano_test, bootstrap_rmse, analyze_by_characteristic,
     analyze_alpha_subset, calculate_vw_statistics, create_evaluation_report,
     create_forecast_comparison_table
@@ -75,6 +75,8 @@ from visualization import (
     plot_horizon_analysis, plot_size_analysis, create_summary_table,
     save_all_figures, adjust_figure_for_presentation
 )
+
+from scipy import stats
 
 # Import validation module if it exists
 try:
@@ -321,7 +323,8 @@ def main():
         mae_zero = calculate_mae(errors_zero)
         
         # Statistical tests
-        t_stat, p_val = paired_t_test(errors_alpha, errors_zero)
+        diff = np.abs(errors_alpha) - np.abs(errors_zero)
+        t_stat, p_val = stats.ttest_1samp(diff, 0.0, nan_policy='omit')
         dm_stat, dm_pval, dm_details = diebold_mariano_test(errors_alpha, errors_zero, horizon=horizon)
         
         # Bootstrap CIs

--- a/models.py
+++ b/models.py
@@ -11,12 +11,13 @@ import warnings
 import statsmodels.api as sm
 from scipy import stats
 
-from config import MODEL_CONFIG, PRESENTATION_CONFIG
+from config import MODEL_CONFIG, PRESENTATION_CONFIG, OUTPUT_CONFIG
 
 # === SECTION 1: DATA VALIDATION AND COLUMN CHECKING ===
 
-def validate_columns(data: pd.DataFrame, required_cols: List[str], 
-                    model_name: str = "Model") -> Dict[str, str]:
+def validate_columns(data: pd.DataFrame, required_cols: List[str],
+                    model_name: str = "Model",
+                    verbose: bool = False) -> Dict[str, str]:
     """
     Validate that required columns exist and check their data types.
     
@@ -57,7 +58,7 @@ def validate_columns(data: pd.DataFrame, required_cols: List[str],
                     raise TypeError(f"Cannot convert column '{col}' to numeric type") from exc
     
     # Print validation summary if verbose
-    if MODEL_CONFIG.get('validate_estimations', True):
+    if verbose and MODEL_CONFIG.get('validate_estimations', True):
         print(f"\n{model_name} Column Validation:")
         print("-" * 50)
         for col, dtype in col_types.items():
@@ -246,7 +247,9 @@ def estimate_capm(data: pd.DataFrame,
     # Validate columns if requested
     if validate_data:
         required_cols = ['RET', 'RF', 'Mkt-RF']
-        col_types = validate_columns(data, required_cols, "CAPM")
+        col_types = validate_columns(
+            data, required_cols, "CAPM", verbose=OUTPUT_CONFIG.get('verbose', False)
+        )
         data_quality = check_estimation_data_quality(data)
     
     # Prepare data - ensure we have numeric arrays
@@ -338,7 +341,9 @@ def estimate_ff3(data: pd.DataFrame,
     # Validate columns
     if validate_data:
         required_cols = ['RET', 'RF', 'Mkt-RF', 'SMB', 'HML']
-        col_types = validate_columns(data, required_cols, "FF3")
+        col_types = validate_columns(
+            data, required_cols, "FF3", verbose=OUTPUT_CONFIG.get('verbose', False)
+        )
     
     # Prepare data
     y = pd.to_numeric(data['RET'] - data['RF'], errors='coerce').values


### PR DESCRIPTION
## Summary
- Recompute t-tests within each horizon using absolute error differences
- Apply HAC variance with `maxlag = max(1, h-1)` for Diebold-Mariano tests
- Gate column validation prints behind a verbose flag

## Testing
- `python -m py_compile evaluation.py main.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_689f9b013ae88326a707a2e12bfaebe2