### PR TITLE
Use CRSP value-weighted market return for CAPM

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,7 +115,7 @@ def main():
     
     # Load data
     crsp_df = load_crsp_data()
-    # For CAPM we still use FF3 file but only Mkt-RF and RF columns
+    # Load Fama-French data for risk-free rate (and other factors if needed)
     ff_df = load_ff_factors()
     
     # Merge and prepare
@@ -213,8 +213,8 @@ def main():
                     
                     # Generate forecasts
                     forecast_row = sample['forecast_data']
-                    mkt_excess = forecast_row['Mkt-RF']
                     rf = forecast_row['RF']
+                    mkt_excess = forecast_row['MKT'] - rf
                     
                     forecast_alpha = forecast_capm_return(alpha, beta, mkt_excess, rf, use_alpha=True)
                     forecast_zero = forecast_capm_return(alpha, beta, mkt_excess, rf, use_alpha=False)

--- a/sampling.py
+++ b/sampling.py
@@ -298,7 +298,7 @@ def sample_events(merged_data: pd.DataFrame,
             forecast_data = stock_data.iloc[forecast_idx]
             
             # Validate forecast day
-            if pd.isna(forecast_data['RET']) or pd.isna(forecast_data['Mkt-RF']):
+            if pd.isna(forecast_data['RET']) or pd.isna(forecast_data['MKT']):
                 valid_for_all_horizons = False
                 window_tracker.record_rejection(f"missing_forecast_h{horizon}")
                 break
@@ -445,7 +445,7 @@ def sample_events_value_weighted(merged_data: pd.DataFrame,
                 window_tracker.record_rejection(f"no_data_h{horizon}")
                 break
             forecast_data = stock_data.iloc[forecast_idx]
-            if pd.isna(forecast_data['RET']) or pd.isna(forecast_data['Mkt-RF']):
+            if pd.isna(forecast_data['RET']) or pd.isna(forecast_data['MKT']):
                 valid_for_all_horizons = False
                 window_tracker.record_rejection(f"missing_forecast_h{horizon}")
                 break


### PR DESCRIPTION
## Summary
- derive CRSP value-weighted market return (`MKT`) in analysis data and ensure it is always available
- update CAPM estimation and sampling to use the consistent `MKT` series instead of Fama-French `Mkt-RF`
- clarify market proxy choice in comments and documentation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f9f228f6c8326b92fa07e965b6165