### PR TITLE
Fix significance star placement in horizon analysis

### DIFF
--- a/visualization.py
+++ b/visualization.py
@@ -184,17 +184,30 @@ def plot_horizon_analysis(all_results: Dict[int, dict],
     
     # Bottom: Improvement
     bars = ax2.bar(horizons, improvements, color='darkgreen', alpha=0.7)
-    
-    # Add significance stars
+    ax2.margins(y=0.2)  # add headroom for annotations
+
+    # Add significance stars with offsets to keep them inside the plot
     for i, h in enumerate(horizons):
         if 'p_value' in all_results[h]:
             p_val = all_results[h]['p_value']
+            stars = ''
             if p_val < 0.01:
-                ax2.text(h, improvements[i] + 0.5, '***', ha='center')
+                stars = '***'
             elif p_val < 0.05:
-                ax2.text(h, improvements[i] + 0.5, '**', ha='center')
+                stars = '**'
             elif p_val < 0.10:
-                ax2.text(h, improvements[i] + 0.5, '*', ha='center')
+                stars = '*'
+            if stars:
+                offset = 5 if improvements[i] >= 0 else -5
+                va = 'bottom' if improvements[i] >= 0 else 'top'
+                ax2.annotate(
+                    stars,
+                    xy=(h, improvements[i]),
+                    xytext=(0, offset),
+                    textcoords='offset points',
+                    ha='center',
+                    va=va
+                )
     
     ax2.axhline(0, color='black', linestyle='-', alpha=0.5)
     ax2.set_xlabel('Forecast Horizon (days)')


### PR DESCRIPTION
## Summary
- keep significance annotations within the plot area of horizon analysis, offsetting stars above or below bars based on improvement sign
- add vertical margins to the improvement subplot for clearer annotation spacing

## Testing
- `python -m py_compile visualization.py`
- `python - <<'PY'
from visualization import plot_horizon_analysis
all_results={1:{'rmse_alpha':0.024,'rmse_zero':0.025,'rmse_improvement_pct':-0.5,'p_value':0.04},
             5:{'rmse_alpha':0.035,'rmse_zero':0.037,'rmse_improvement_pct':0.8,'p_value':0.009}}
plot_horizon_analysis(all_results, save_path='horizon_test.pdf')
print('generated')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689fa73865c083268a81d5f893a2e1a9