### PR TITLE
Add missing presentation config, format helpers, and robust model comparison

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,8 +1,7 @@
-"""
-config.py - Simplified configuration for event study analysis.
-"""
+"""Simplified configuration and formatting utilities for the analysis."""
 
 import os
+import numpy as np
 
 # === CORE PARAMETERS ===
 SAMPLING_CONFIG = {
@@ -25,8 +24,8 @@ DATA_FILTERS = {
 }
 
 # === MODEL SETTINGS ===
+# Always compare CAPM with FF3; no need to specify a base model
 MODEL_CONFIG = {
-    'base_model': 'capm',                # 'capm' or 'ff3'
     'winsorize_level': 0.005,            # 0.5% in each tail
 }
 
@@ -43,6 +42,15 @@ OUTPUT_CONFIG = {
     'figure_dpi': 300,
     'table_format': 'latex',
     'verbose': True,
+}
+
+# === PRESENTATION SETTINGS ===
+# Store captions and notes by table/figure name for flexibility
+PRESENTATION_CONFIG = {
+    'forecast_comparison_table': {
+        'caption': 'Forecast accuracy comparison: CAPM vs FF3',
+        'notes': 'RMSE reported in percentage points. Lower is better.',
+    }
 }
 
 # === FILE PATHS ===
@@ -78,6 +86,39 @@ def create_output_dirs():
     ]
     for dir_path in dirs_to_create:
         os.makedirs(dir_path, exist_ok=True)
+
+
+# === FORMATTING UTILITIES ===
+
+def format_percentage(value: float, decimals: int = 2) -> str:
+    """Format a decimal value as a percentage string."""
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return "N/A"
+    return f"{value * 100:.{decimals}f}%"
+
+
+def format_number(value: float, kind: str = 'default') -> str:
+    """Format numeric values with sensible defaults by type."""
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return "N/A"
+    decimals = {
+        'coefficients': 4,
+        'statistics': 2,
+        'default': 2,
+    }
+    d = decimals.get(kind, decimals['default'])
+    return f"{value:.{d}f}"
+
+
+def get_significance_stars(p_value: float) -> str:
+    """Return conventional significance stars for a p-value."""
+    if p_value < 0.01:
+        return '***'
+    if p_value < 0.05:
+        return '**'
+    if p_value < 0.10:
+        return '*'
+    return ''
 
 # Run setup when imported
 create_output_dirs()

--- a/evaluation.py
+++ b/evaluation.py
@@ -997,7 +997,7 @@ def create_forecast_comparison_table(results_by_horizon: Dict[int, pd.DataFrame]
         # Create LaTeX table
         table = "\\begin{table}[ht]\n"
         table += "\\centering\n"
-        table += f"\\caption{{{PRESENTATION_CONFIG['table_caption']}}}\n"
+        table += f"\\caption{{{PRESENTATION_CONFIG['forecast_comparison_table']['caption']}}}\n"
         table += "\\label{tab:forecast_comparison}\n"
         table += "\\begin{tabular}{lcccccc}\n"
         table += "\\hline\\hline\n"
@@ -1034,7 +1034,7 @@ def create_forecast_comparison_table(results_by_horizon: Dict[int, pd.DataFrame]
         table += "\\end{tabular}\n"
         table += "\\begin{tablenotes}\n"
         table += "\\small\n"
-        table += f"\\item {PRESENTATION_CONFIG['table_notes']}\n"
+        table += f"\\item {PRESENTATION_CONFIG['forecast_comparison_table']['notes']}\n"
         table += "\\end{tablenotes}\n"
         table += "\\end{table}\n"
         
@@ -1065,7 +1065,7 @@ def create_forecast_comparison_table(results_by_horizon: Dict[int, pd.DataFrame]
                 table += "*"
             table += " |\n"
         
-        table += "\n" + PRESENTATION_CONFIG['table_notes']
+        table += "\n" + PRESENTATION_CONFIG['forecast_comparison_table']['notes']
 
     return table
 
@@ -1213,11 +1213,26 @@ def check_forecast_quality(results_df: pd.DataFrame) -> Dict[str, any]:
 # === SECTION 7: MODEL COMPARISON UTILITIES ===
 
 def compare_models_performance(results_df: pd.DataFrame) -> Dict[str, float]:
-    """Compare CAPM and FF3 forecast performance without re-estimation."""
+    """Compare CAPM and FF3 forecast performance without re-estimation.
+
+    Supports DataFrames that either use explicit model-specific error columns
+    (e.g. ``error_capm_alpha``) or the generic ``error_alpha``/``error_zero``
+    pair for CAPM. Raises a helpful error if FF3 errors are missing.
+    """
+
+    # Determine which columns hold CAPM errors
+    capm_alpha_col = 'error_capm_alpha' if 'error_capm_alpha' in results_df.columns else 'error_alpha'
+    capm_zero_col = 'error_capm_zero' if 'error_capm_zero' in results_df.columns else 'error_zero'
+
+    # FF3 errors must be present to perform the comparison
+    if 'error_ff3_alpha' not in results_df.columns or 'error_ff3_zero' not in results_df.columns:
+        raise KeyError(
+            "results_df must contain 'error_ff3_alpha' and 'error_ff3_zero' columns to compare against CAPM"
+        )
 
     comparisons = {
-        'CAPM with α': calculate_rmse(results_df['error_capm_alpha']),
-        'CAPM no α': calculate_rmse(results_df['error_capm_zero']),
+        'CAPM with α': calculate_rmse(results_df[capm_alpha_col]),
+        'CAPM no α': calculate_rmse(results_df[capm_zero_col]),
         'FF3 with α': calculate_rmse(results_df['error_ff3_alpha']),
         'FF3 no α': calculate_rmse(results_df['error_ff3_zero']),
     }
@@ -1254,9 +1269,13 @@ def compare_models_performance(results_df: pd.DataFrame) -> Dict[str, float]:
     # Statistical test: does FF3 beat CAPM?
     t_stat, p_val = stats.ttest_rel(
         results_df['error_ff3_alpha'].abs(),
-        results_df['error_capm_alpha'].abs()
+        results_df[capm_alpha_col].abs()
     )
     print(f"\nFF3 vs CAPM paired t-test: t={t_stat:.3f}, p={p_val:.4f}")
-    print(f"Average R² improvement from factors: {results_df['r2_increment'].mean():.3f}")
+
+    if 'r2_increment' in results_df.columns:
+        print(f"Average R² improvement from factors: {results_df['r2_increment'].mean():.3f}")
+    else:
+        print("Average R² improvement from factors: N/A")
 
     return comparisons


### PR DESCRIPTION
## Summary
- define `PRESENTATION_CONFIG` with caption and notes for forecast comparison table
- provide formatting helpers (`format_percentage`, `format_number`, `get_significance_stars`)
- remove unused `base_model` flag to always compare CAPM with FF3
- nest caption and notes under `forecast_comparison_table`
- make `compare_models_performance` resilient to datasets lacking explicit CAPM error columns

## Testing
- `python -m py_compile config.py evaluation.py models.py main.py`
- `python - <<'PY'
import pandas as pd
import evaluation

df = pd.DataFrame({
    'error_alpha':[0.1,-0.2,0.05],
    'error_zero':[0.15,-0.25,0.1],
    'error_ff3_alpha':[0.08,-0.22,0.04],
    'error_ff3_zero':[0.12,-0.27,0.09],
    'r2_increment':[0.02,0.03,0.01],
})

evaluation.compare_models_performance(df)
PY`
- `python main.py` *(fails: FileNotFoundError: data/CRSP 1970-2024.parquet)*

------
https://chatgpt.com/codex/tasks/task_e_68a05bb5ccfc832689c49b75a820423a