### PR TITLE
Handle CAPM validation and flexible model comparison

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -1217,18 +1217,21 @@ def compare_models_performance(results_df: pd.DataFrame) -> Dict[str, float]:
 
     Supports DataFrames that either use explicit model-specific error columns
     (e.g. ``error_capm_alpha``) or the generic ``error_alpha``/``error_zero``
-    pair for CAPM. Raises a helpful error if FF3 errors are missing.
+    pair for CAPM. If FF3 error columns are missing, the function returns a
+    CAPM-only comparison instead of raising an exception.
     """
 
     # Determine which columns hold CAPM errors
     capm_alpha_col = 'error_capm_alpha' if 'error_capm_alpha' in results_df.columns else 'error_alpha'
     capm_zero_col = 'error_capm_zero' if 'error_capm_zero' in results_df.columns else 'error_zero'
 
-    # FF3 errors must be present to perform the comparison
+    # If FF3 errors are missing, fall back to CAPM-only comparison
     if 'error_ff3_alpha' not in results_df.columns or 'error_ff3_zero' not in results_df.columns:
-        raise KeyError(
-            "results_df must contain 'error_ff3_alpha' and 'error_ff3_zero' columns to compare against CAPM"
-        )
+        print("\nFF3 errors not found; returning CAPM comparison only.")
+        return {
+            'CAPM with α': calculate_rmse(results_df[capm_alpha_col]),
+            'CAPM no α': calculate_rmse(results_df[capm_zero_col]),
+        }
 
     comparisons = {
         'CAPM with α': calculate_rmse(results_df[capm_alpha_col]),

--- a/models.py
+++ b/models.py
@@ -224,10 +224,30 @@ def calculate_vw_beta(results_df: pd.DataFrame) -> Dict[str, any]:
 
 # === SECTION 3: MODEL ESTIMATION WITH VALIDATION ===
 
-def estimate_capm(data: pd.DataFrame, min_obs: int = 200) -> Tuple[float, float, dict]:
+def estimate_capm(data: pd.DataFrame,
+                  min_obs: int = 200,
+                  validate_data: bool = None) -> Tuple[float, float, dict]:
+    """Estimate CAPM model with optional data validation.
+
+    Args:
+        data: Estimation window data containing ``RET``, ``RF`` and ``Mkt-RF``.
+        min_obs: Minimum number of observations required for estimation.
+        validate_data: When ``True`` performs column existence and type checks
+            using :func:`validate_columns`. The default is ``False``.
     """
-    Estimate CAPM model - simplified version.
-    """
+
+    if validate_data is None:
+        validate_data = False
+
+    if validate_data:
+        required = ['RET', 'RF', 'Mkt-RF']
+        validate_columns(
+            data,
+            required,
+            "CAPM",
+            verbose=OUTPUT_CONFIG.get('verbose', False)
+        )
+
     # Prepare data
     y = (data['RET'] - data['RF']).values
     X = data['Mkt-RF'].values.reshape(-1, 1)


### PR DESCRIPTION
## Summary
- Allow `estimate_capm` to accept an optional `validate_data` flag for column checks
- Make `compare_models_performance` tolerate CAPM-only results when FF3 errors are missing
- Let `plot_model_comparison` fall back to CAPM-only plots if FF3 columns are absent

## Testing
- `python -m py_compile models.py evaluation.py visualization.py main.py`
- `python - <<'PY'
import pandas as pd, numpy as np, matplotlib
matplotlib.use('Agg')
from evaluation import compare_models_performance
from visualization import plot_model_comparison
capm_df=pd.DataFrame({'error_capm_alpha':[0.1,-0.2],'error_capm_zero':[0.2,-0.3]})
compare_models_performance(capm_df); plot_model_comparison(capm_df)
ff3_df=pd.DataFrame({'error_capm_alpha':[0.1,-0.2],'error_capm_zero':[0.2,-0.3],'error_ff3_alpha':[0.05,-0.1],'error_ff3_zero':[0.15,-0.25],'r2_capm':[0.1,0.2],'r2_ff3':[0.2,0.3],'alpha_capm':[0.01,0.02],'alpha_ff3':[0.005,0.015],'beta_capm':[1.1,0.9],'beta_mkt_ff3':[1.0,0.95],'beta_smb':[0.2,0.1],'beta_hml':[0.3,0.2]})
compare_models_performance(ff3_df); plot_model_comparison(ff3_df)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a06337489c832685b948ae1ce8d236