### PR TITLE
Handle missing error columns in model comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Out-Of-Sample-Forecast-Comparison
 Seminar Thesis
+
+## Generating a sample dataset
+
+The full CRSP dataset used in the project is too large to include in the
+repository.  To facilitate testing, a helper script
+`sample_data_generator.py` can create a much smaller Parquet file with a
+limited number of pre-sampled windows:
+
+```bash
+python sample_data_generator.py /path/to/full/CRSP.parquet
+```
+
+The resulting file is written to `data/crsp_sample.parquet` and is small
+enough to commit to the repo.

--- a/config.py
+++ b/config.py
@@ -55,7 +55,7 @@ PRESENTATION_CONFIG = {
 
 # === FILE PATHS ===
 DATA_PATHS = {
-    'crsp_file': 'data/CRSP 1970-2024.parquet',
+    'crsp_file': 'data/crsp_sample.parquet',
     'ff_factors': 'data/F-F_Research_Data_Factors_daily.csv',
 }
 

--- a/evaluation.py
+++ b/evaluation.py
@@ -1215,26 +1215,17 @@ def check_forecast_quality(results_df: pd.DataFrame) -> Dict[str, any]:
 def compare_models_performance(results_df: pd.DataFrame) -> Dict[str, float]:
     """Compare CAPM and FF3 forecast performance without re-estimation.
 
-    Supports DataFrames that either use explicit model-specific error columns
-    (e.g. ``error_capm_alpha``) or the generic ``error_alpha``/``error_zero``
-    pair for CAPM. If FF3 error columns are missing, the function returns a
-    CAPM-only comparison instead of raising an exception.
+    Expects CAPM errors to be stored in ``error_capm_alpha`` and
+    ``error_capm_zero``. If FF3 error columns are missing, the function
+    returns a CAPM-only comparison instead of raising an exception.
     """
 
-    # Determine which columns hold CAPM errors
-    capm_alpha_col = (
-        'error_capm_alpha' if 'error_capm_alpha' in results_df.columns
-        else 'error_alpha' if 'error_alpha' in results_df.columns
-        else None
-    )
-    capm_zero_col = (
-        'error_capm_zero' if 'error_capm_zero' in results_df.columns
-        else 'error_zero' if 'error_zero' in results_df.columns
-        else None
-    )
+    # CAPM errors are expected under fixed column names
+    capm_alpha_col = 'error_capm_alpha'
+    capm_zero_col = 'error_capm_zero'
 
-    # If even the CAPM error columns are missing, we cannot compute any comparison
-    if capm_alpha_col is None or capm_zero_col is None:
+    # If the CAPM error columns are missing, we cannot compute any comparison
+    if capm_alpha_col not in results_df.columns or capm_zero_col not in results_df.columns:
         print("\nCAPM errors not found; skipping model comparison.")
         return {}
 

--- a/evaluation.py
+++ b/evaluation.py
@@ -1222,8 +1222,21 @@ def compare_models_performance(results_df: pd.DataFrame) -> Dict[str, float]:
     """
 
     # Determine which columns hold CAPM errors
-    capm_alpha_col = 'error_capm_alpha' if 'error_capm_alpha' in results_df.columns else 'error_alpha'
-    capm_zero_col = 'error_capm_zero' if 'error_capm_zero' in results_df.columns else 'error_zero'
+    capm_alpha_col = (
+        'error_capm_alpha' if 'error_capm_alpha' in results_df.columns
+        else 'error_alpha' if 'error_alpha' in results_df.columns
+        else None
+    )
+    capm_zero_col = (
+        'error_capm_zero' if 'error_capm_zero' in results_df.columns
+        else 'error_zero' if 'error_zero' in results_df.columns
+        else None
+    )
+
+    # If even the CAPM error columns are missing, we cannot compute any comparison
+    if capm_alpha_col is None or capm_zero_col is None:
+        print("\nCAPM errors not found; skipping model comparison.")
+        return {}
 
     # If FF3 errors are missing, fall back to CAPM-only comparison
     if 'error_ff3_alpha' not in results_df.columns or 'error_ff3_zero' not in results_df.columns:

--- a/sample_data_generator.py
+++ b/sample_data_generator.py
@@ -1,0 +1,138 @@
+"""Utility to create a small CRSP dataset for testing.
+
+This module allows extracting a subset of the full CRSP dataset that
+contains a limited number of valid samples.  The resulting Parquet file
+is small enough to commit to version control (\u003c25 MB) yet preserves the
+structure required by the sampling and modelling pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+
+from config import SAMPLING_CONFIG, DATA_PATHS
+from data_loader import load_crsp_data, load_ff_factors, prepare_analysis_data
+from sampling import sample_events_value_weighted
+
+
+def build_subset_from_samples(samples: Dict[int, List[dict]]) -> pd.DataFrame:
+    """Compile unique PERMNO-date rows from sampled events.
+
+    Parameters
+    ----------
+    samples : dict
+        Output of ``sample_events_value_weighted`` where each horizon
+        maps to a list of sample dictionaries containing estimation and
+        forecast data.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Deduplicated DataFrame containing all rows required for the
+        sampled estimation and forecast windows.
+    """
+    frames = []
+    for horizon_samples in samples.values():
+        for sample in horizon_samples:
+            frames.append(sample["estimation_data"])
+            # ``forecast_data`` is a Series; convert to DataFrame
+            frames.append(sample["forecast_data"].to_frame().T)
+
+    subset = pd.concat(frames, ignore_index=True)
+    subset = subset.drop_duplicates(subset=["PERMNO", "date"])
+    subset = subset.sort_values(["PERMNO", "date"]).reset_index(drop=True)
+    return subset
+
+
+def extract_sample_dataset(
+    full_crsp_path: str,
+    output_path: str = "data/crsp_sample.parquet",
+    n_samples: int = 105,
+    estimation_window: int = SAMPLING_CONFIG["estimation_window"],
+    forecast_horizons: List[int] | None = None,
+    random_seed: int | None = SAMPLING_CONFIG.get("random_seed"),
+    verbose: bool = True,
+) -> pd.DataFrame:
+    """Create and save a reduced CRSP dataset with sampled windows.
+
+    This function loads the full CRSP Parquet file and Fama-French
+    factor data, draws random samples using the project's standard
+    sampling routine, and saves a deduplicated subset of the data to a
+    new Parquet file.
+
+    Parameters
+    ----------
+    full_crsp_path : str
+        Path to the full CRSP Parquet file on the user's machine.
+    output_path : str, default ``"data/crsp_sample.parquet"``
+        Destination for the reduced dataset.
+    n_samples : int, default ``105``
+        Number of sample windows to draw (includes a buffer above the
+        100 used in analysis).
+    estimation_window : int
+        Length of estimation window in trading days.
+    forecast_horizons : list[int], optional
+        Forecast horizons to accommodate.  Defaults to the configuration
+        value.
+    random_seed : int, optional
+        Seed for reproducible sampling.
+    verbose : bool
+        Whether to print progress information.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The subset DataFrame that was written to ``output_path``.
+    """
+    if forecast_horizons is None:
+        forecast_horizons = SAMPLING_CONFIG["forecast_horizons"]
+
+    # Load full data
+    crsp_df = load_crsp_data(full_crsp_path)
+    ff_df = load_ff_factors(DATA_PATHS["ff_factors"])
+    merged_df = prepare_analysis_data(crsp_df, ff_df)
+
+    # Draw samples
+    samples = sample_events_value_weighted(
+        merged_df,
+        n_samples=n_samples,
+        estimation_window=estimation_window,
+        forecast_horizons=forecast_horizons,
+        config=SAMPLING_CONFIG,
+        random_seed=random_seed,
+        verbose=verbose,
+    )
+
+    # Compile subset and save
+    subset = build_subset_from_samples(samples)
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    subset.to_parquet(output_path, index=False)
+    size_mb = os.path.getsize(output_path) / (1024 * 1024)
+    if verbose:
+        print(
+            f"Saved {len(subset):,} rows "
+            f"({subset['PERMNO'].nunique()} stocks) to {output_path} "
+            f"[{size_mb:.2f} MB]"
+        )
+
+    return subset
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Create a small CRSP sample dataset.")
+    parser.add_argument("full_crsp_path", help="Path to the full CRSP Parquet file")
+    parser.add_argument("--output", default="data/crsp_sample.parquet", help="Output path")
+    parser.add_argument("--n-samples", type=int, default=105, help="Number of sample windows to draw")
+    args = parser.parse_args()
+
+    extract_sample_dataset(
+        full_crsp_path=args.full_crsp_path,
+        output_path=args.output,
+        n_samples=args.n_samples,
+    )


### PR DESCRIPTION
## Summary
- Avoid KeyError in `compare_models_performance` by safely detecting absent CAPM error columns
- Provide informative messages when CAPM or FF3 errors are missing

## Testing
- `python - <<'PY'
import pandas as pd
from evaluation import compare_models_performance
print('Case 1: No columns')
compare_models_performance(pd.DataFrame())
print('\nCase 2: CAPM errors only')
df = pd.DataFrame({'error_capm_alpha':[0.1, -0.2], 'error_capm_zero':[0.2, -0.1]})
compare_models_performance(df)
print('\nCase 3: CAPM and FF3 errors')
df2 = pd.DataFrame({'error_capm_alpha':[0.1, -0.2], 'error_capm_zero':[0.2, -0.1], 'error_ff3_alpha':[0.05,-0.1], 'error_ff3_zero':[0.15,-0.05]})
compare_models_performance(df2)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a0661e667c83268be9e44ec0e0cbb7